### PR TITLE
Add treemap hierarchy chart

### DIFF
--- a/components/hierarchy/lib/hierarchy-visualisation.ts
+++ b/components/hierarchy/lib/hierarchy-visualisation.ts
@@ -1,0 +1,43 @@
+import d3, { d3types } from "../../../lib/external/d3.ts";
+
+export type TableData<T> = Record<string, T>[];
+export type UsefulFunction = (d: unknown) => unknown;
+
+export interface HierarchyVisualisationOptions {
+  table: TableData<string | number>;
+  reduce: UsefulFunction;
+  grouping: UsefulFunction[];
+  dataMapper?: UsefulFunction;
+}
+
+export abstract class HierarchyVisualisation {
+  readonly options: HierarchyVisualisationOptions;
+  root: d3types.HierarchyNode<unknown>;
+  constructor(options: HierarchyVisualisationOptions) {
+    if (options.table === undefined) {
+      throw new Error("Treemap options does not include a table");
+    }
+
+    this.options = {
+      ...options,
+      table: structuredClone(options.table),
+    };
+
+    try {
+      this.root = d3.hierarchy(
+        d3.rollup(
+          this.options.table,
+          this.options.reduce,
+          ...this.options.grouping,
+        ),
+      );
+    } catch (e) {
+      console.error(e.message);
+      throw new Error(
+        "Unable to create root for treemap. Did you provide table, reducer and grouping functions?",
+      );
+    }
+    if (this.options.dataMapper) this.root.each(this.options.dataMapper);
+  }
+  abstract render(): string;
+}

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -10,6 +10,7 @@ export type TreeMapOptions = HierarchyVisualisationOptions & {
   width: number;
   height: number;
   padding: number;
+  valueKey?: string;
   nameMapper: UsefulFunction;
   colourMapper: UsefulFunction;
 };
@@ -18,6 +19,7 @@ export class TreeMap extends HierarchyVisualisation {
   width: number;
   height: number;
   padding: number;
+  valueKey?: string;
   nameMapper: UsefulFunction;
   colourMapper: UsefulFunction;
 
@@ -33,12 +35,33 @@ export class TreeMap extends HierarchyVisualisation {
     this.width = options.width;
     this.height = options.height;
     this.padding = options.padding || 0;
+    this.valueKey = options.valueKey;
     this.nameMapper = options.nameMapper;
     this.colourMapper = options.colourMapper;
   }
+  /**
+   * Prepare the hierarchy in this.root for treemapping
+   * 
+   * @returns void
+   */
   prepareTreemap() {
-    // TODO Deal with trees with a value
-    this.root.count().sort(function (a, b) {
+    if (this.valueKey) {
+      /**
+       * If the object was instantiated with a `valueKey`, then it calls the `sum` method of the `root`.
+       */
+      this.root.sum((d) => {
+        return d[this.valueKey] || 0;
+      });
+    } else {
+      /**
+       * Otherwise, it uses the `count` method of `root`.
+       */
+      this.root.count()
+    }
+    /**
+     * Sort the `root`
+     */
+    this.root.sort(function (a, b) {
       return b.height - a.height || b.value - a.value;
     });
     return d3.treemap()

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -54,8 +54,7 @@ export class TreeMap extends HierarchyVisualisation {
 
     // Create the base svg
     const svg = d3.create("svg")
-      .attr("viewBox", [0, 0, this.width, this.height])
-      .classed('chart', true);
+      .attr("viewBox", [0, 0, this.width, this.height]);
 
     svg.append('style').text(`
       div {

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -54,7 +54,8 @@ export class TreeMap extends HierarchyVisualisation {
 
     // Create the base svg
     const svg = d3.create("svg")
-      .attr("viewBox", [0, 0, this.width, this.height]);
+      .attr("viewBox", [0, 0, this.width, this.height])
+      .classed('chart', true);
 
     svg.append('style').text(`
       div {

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -89,7 +89,7 @@ export class TreeMap extends HierarchyVisualisation {
 
     // Create the base svg
     const svg = d3.create("svg")
-      .classed('treemap', true)
+      .classed('oi-viz tree-map treemap', true)
       .attr("viewBox", [0, 0, this.width, this.height]);
 
     svg.append('style').text(`

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -79,10 +79,10 @@ export class TreeMap extends HierarchyVisualisation {
 
     const treeCell = node.enter().append("g")
       .attr('data-height', d => d.height)
+      .classed('series', true)
       .attr("transform", d => `translate(${d.x0} ${d.y0})`);
 
     treeCell.append("rect")
-      .classed('series', true)
       .attr("x", 0).attr("y", 0)
       .attr("width", d => d.x1 - d.x0)
       .attr("height", d => d.y1 - d.y0)

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -63,12 +63,6 @@ export class TreeMap extends HierarchyVisualisation {
         padding:5px;
         border:none;
       }
-      [data-height] foreignObject {
-        display: none;
-      }
-      [data-height="0"] foreignObject {
-        display: initial;
-      }
     `);
     
     // Create a group to hold the cells

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -1,0 +1,106 @@
+import d3 from "../../../lib/external/d3.ts";
+
+import {
+  HierarchyVisualisation,
+  HierarchyVisualisationOptions,
+UsefulFunction,
+} from "./hierarchy-visualisation.ts";
+
+export type TreeMapOptions = HierarchyVisualisationOptions & {
+  width: number;
+  height: number;
+  padding: number;
+  nameMapper: UsefulFunction;
+  colourMapper: UsefulFunction;
+};
+
+export class TreeMap extends HierarchyVisualisation {
+  width: number;
+  height: number;
+  padding: number;
+  nameMapper: UsefulFunction;
+  colourMapper: UsefulFunction;
+
+  constructor(options: TreeMapOptions) {
+    super({
+      table: options.table,
+      reduce: options.reduce,
+      grouping: options.grouping,
+      dataMapper: options.dataMapper,
+    });
+    this.width = options.width;
+    this.height = options.height;
+    this.padding = options.padding;
+    this.nameMapper = options.nameMapper;
+    this.colourMapper = options.colourMapper;
+  }
+  prepareTreemap() {
+    // Count the number of cells
+    this.root.count().sort(function (a, b) {
+      return b.height - a.height || b.value - a.value;
+    });
+    return d3.treemap()
+      .size([
+        this.width,
+        this.height,
+      ])
+      .padding(this.padding);
+  }
+  render() {
+    const treemap = this.prepareTreemap();
+    treemap(this.root);
+
+    // Create the base svg
+    const svg = d3.create("svg")
+      .attr("viewBox", [0, 0, this.width, this.height]);
+
+    svg.append('style').text(`
+      div {
+        color: white;
+        font-size:10px;
+        padding:5px;
+        border:none;
+      }
+      [data-height] foreignObject {
+        display: none;
+      }
+      [data-height="0"] foreignObject {
+        display: initial;
+      }
+    `);
+    
+    // Create a group to hold the cells
+    const treeCells = svg.append("g")
+      .attr("fill", "#aaa")
+      .attr("stroke", "#555")
+      .attr("stroke-width", 1);
+
+    const nodes = this.root;
+
+    // Attach the nodes to the top level group
+    const node = treeCells.selectAll("g")
+      .data(nodes);
+
+    const treeCell = node.enter().append("g")
+      .attr('data-height', d => d.height)
+      .attr("transform", d => `translate(${d.x0} ${d.y0})`);
+
+    treeCell.append("rect")
+      .attr("x", 0).attr("y", 0)
+      .attr("width", d => d.x1 - d.x0)
+      .attr("height", d => d.y1 - d.y0)
+      .attr("fill", this.colourMapper)
+      .append('title')
+      .text(this.nameMapper);
+
+    // Add labels to the leaf nodes
+    treeCell.append('foreignObject')
+      .attr('x', 0).attr('y', 0)
+      .attr('width', d => d.x1 - d.x0)
+      .attr('height', d => d.y1 - d.y0)
+      .append('div')
+      .text(d => d.data.title);
+
+    return svg.node();
+  }
+}

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -28,14 +28,16 @@ export class TreeMap extends HierarchyVisualisation {
       grouping: options.grouping,
       dataMapper: options.dataMapper,
     });
+    if (!options.width) throw new Error('TreeMap options must include a numeric width');
+    if (!options.height) throw new Error('TreeMap options must include a numeric height');
     this.width = options.width;
     this.height = options.height;
-    this.padding = options.padding;
+    this.padding = options.padding || 0;
     this.nameMapper = options.nameMapper;
     this.colourMapper = options.colourMapper;
   }
   prepareTreemap() {
-    // Count the number of cells
+    // TODO Deal with trees with a value
     this.root.count().sort(function (a, b) {
       return b.height - a.height || b.value - a.value;
     });

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -1,9 +1,10 @@
+import { Colour } from "../../../lib/colour/colour.ts";
 import d3 from "../../../lib/external/d3.ts";
 
 import {
   HierarchyVisualisation,
   HierarchyVisualisationOptions,
-UsefulFunction,
+  UsefulFunction,
 } from "./hierarchy-visualisation.ts";
 
 export type TreeMapOptions = HierarchyVisualisationOptions & {
@@ -131,6 +132,7 @@ export class TreeMap extends HierarchyVisualisation {
       .attr("width", d => (d.x1 - d.x0) * this.ratio)
       .attr('height', d => d.y1 - d.y0)
       .append('div')
+      .style('color', (d) => Colour(this.colourMapper(d)).contrast)
       .text(d => d.data.title);
 
     return svg.node();

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -82,6 +82,7 @@ export class TreeMap extends HierarchyVisualisation {
       .attr("transform", d => `translate(${d.x0} ${d.y0})`);
 
     treeCell.append("rect")
+      .classed('series', true)
       .attr("x", 0).attr("y", 0)
       .attr("width", d => d.x1 - d.x0)
       .attr("height", d => d.y1 - d.y0)

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -88,6 +88,7 @@ export class TreeMap extends HierarchyVisualisation {
 
     // Create the base svg
     const svg = d3.create("svg")
+      .classed('treemap', true)
       .attr("viewBox", [0, 0, this.width, this.height]);
 
     svg.append('style').text(`

--- a/components/hierarchy/lib/tree-map.ts
+++ b/components/hierarchy/lib/tree-map.ts
@@ -92,7 +92,7 @@ export class TreeMap extends HierarchyVisualisation {
       .attr("viewBox", [0, 0, this.width, this.height]);
 
     svg.append('style').text(`
-      div {
+      .treemap foreignObject div {
         color: white;
         font-size:10px;
         padding:5px;

--- a/components/hierarchy/tree_map.ts
+++ b/components/hierarchy/tree_map.ts
@@ -1,0 +1,29 @@
+import { thingOrNameOfThing } from "../../lib/helpers.ts";
+import { UsefulFunction } from "./lib/hierarchy-visualisation.ts";
+import { TreeMap, TreeMapOptions } from "./lib/tree-map.ts";
+
+/**
+ * Wrapper around the TreeMap class which implements the visualisation
+ * @param options 
+ * @returns 
+ */
+export default function (options: {
+  config: TreeMapOptions
+}) {
+  // Clone the data table to avoid breaking the global context
+  options.config.table = structuredClone(options.config.table);
+
+  // Convert references into actual objects
+  // These are for the Hierarchy Visualisation base class
+  options.config.grouping = thingOrNameOfThing<UsefulFunction[]>(options.config.grouping, options);
+  options.config.reduce = thingOrNameOfThing<UsefulFunction>(options.config.reduce, options);
+  if (options.config.dataMapper)
+    options.config.dataMapper = thingOrNameOfThing<UsefulFunction>(options.config.dataMapper, options);
+
+  // These are for the TreeMap class
+  options.config.nameMapper = thingOrNameOfThing<UsefulFunction>(options.config.nameMapper, options);
+  options.config.colourMapper = thingOrNameOfThing<UsefulFunction>(options.config.colourMapper, options);
+
+  const treemap = new TreeMap(options.config);
+  return treemap.render();
+}

--- a/lib/external/d3.ts
+++ b/lib/external/d3.ts
@@ -1,0 +1,11 @@
+import { DOMParser } from "https://esm.sh/linkedom@0.14.25/";
+
+export * as default from "https://esm.sh/d3@7.8.2/";
+export * as d3types from "https://cdn.skypack.dev/-/d3@v7.8.2-xzCqOnvGzQkNaPfc30G2/dist=es2019,mode=types/index";
+
+if (globalThis.document === undefined) {
+  globalThis.document = new DOMParser().parseFromString(
+    `<!DOCTYPE html><html lang="en"><body></body></html>`,
+    "text/html",
+  );
+}

--- a/lib/helpers.test.ts
+++ b/lib/helpers.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, it } from "std/testing/bdd.ts";
+import { assertEquals } from "std/testing/asserts.ts";
+import { resolveData } from "./helpers.ts";
+
+describe("resolveData", () => {
+  let context: Record<string, unknown>;
+
+  beforeEach(() => {
+    context = {
+      "simple": "RESULT",
+      "nested": {
+        "reference": {
+          "path": "RESULT",
+        },
+      },
+    };
+  });
+
+  it("should return a namespace path from the context", () => {
+    assertEquals(resolveData("simple", context), "RESULT");
+  });
+
+  it("should return a nested namespace path from the context", () => {
+    assertEquals(resolveData("nested.reference.path", context), "RESULT");
+  });
+});

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,0 +1,33 @@
+/**
+ * Recursive function to resolve data from a given context
+ *
+ * @param ref dot-separated reference to the dataset
+ * @param context the context in which to search for the data
+ * @returns
+ */
+export function resolveData<T = unknown>(
+  ref: string,
+  context: Record<string, T>,
+): T {
+  // Initialise the result to be the whole context.
+  // If we provide no key, we should return the whole thing!
+  let result = context;
+  // Split the ref by the '.' character and iterate over the resulting array
+  for (const key of ref.split('.')) {
+    result = result[key] as Record<string, T>;
+  }
+  return result as T;
+}
+
+/**
+ * Wrapper around resolveContext which checks if the ref is a string.
+ * If it is the function returns the resolved version.
+ * If not a string, returns the original object.
+ * 
+ * @param thingOrName an object or a string which refers to the object
+ * @returns an object
+ */
+export function thingOrNameOfThing<T = unknown>(thingOrName: string | T, context: Record<string, unknown> ): T {
+  if (typeof thingOrName !== 'string') return thingOrName as T;
+  return resolveData(thingOrName as string, context) as T;
+}


### PR DESCRIPTION
Adds treemap class, with base classes that should support other hierarchy charts.

Uses `d3.js` to render the charts.